### PR TITLE
Add Battery Stat

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ I created `Catnap🌿` (originally known as `Catnip`) as a playful, simple syste
     <li>shell</li>
     <li>terminal</li>
     <li>memory</li>
+    <li>battery</li>
     <li>disk space</li>
     <li>cpu info</li>
     <li>packages</li>

--- a/config/config.toml
+++ b/config/config.toml
@@ -21,7 +21,7 @@ packages  = {icon = " ", name = "packages", color = "(GN)"}  # WARNING: Resou
 # cpu       = {icon = " ", name = "cpu", color = "(RD)"}
 disk_0    = {icon = " ", name = "disk", color = "(GN)"}
 memory    = {icon = " ", name = "memory", color = "(YW)"}
-battery    = {icon = " ", name = "battery", color = "(YW)"}
+# battery    = {icon = " ", name = "battery", color = "(YW)"} # Please set the env var CATNAP_BATTERY before enabling.
 # weather   = {icon = " ", name = "weather", color = "(BE)"} # Requires curl and an emoji font. | WARNING: Resource Intensive
 sep_color = "SEPARATOR"
 colors    = {icon = " ", name = "colors", color = "!DT!", symbol = ""}

--- a/config/config.toml
+++ b/config/config.toml
@@ -16,12 +16,12 @@ kernel    = {icon = " ", name = "kernel", color = "(MA)"}
 desktop   = {icon = " ", name = "desktop", color = "(CN)"}
 # terminal  = {icon = " ", name = "term", color = "(RD)"}
 # shell     = {icon = " ", name = "shell", color = "(MA)"}
-packages  = {icon = " ", name = "packages", color = "(GN)"}  # WARNING: Resource Intensive
+# packages  = {icon = " ", name = "packages", color = "(RD)"}  # WARNING: Resource Intensive
 # gpu       = {icon = "󱔐 ", name = "gpu", color = "(MA)"}      # WARNING: Resource Intensive
 # cpu       = {icon = " ", name = "cpu", color = "(RD)"}
 disk_0    = {icon = " ", name = "disk", color = "(GN)"}
 memory    = {icon = " ", name = "memory", color = "(YW)"}
-# battery    = {icon = " ", name = "battery", color = "(YW)"} # Please set the env var CATNAP_BATTERY before enabling.
+# battery    = {icon = " ", name = "battery", color = "(GN)"}
 # weather   = {icon = " ", name = "weather", color = "(BE)"} # Requires curl and an emoji font. | WARNING: Resource Intensive
 sep_color = "SEPARATOR"
 colors    = {icon = " ", name = "colors", color = "!DT!", symbol = ""}

--- a/config/config.toml
+++ b/config/config.toml
@@ -21,6 +21,7 @@ packages  = {icon = " ", name = "packages", color = "(GN)"}  # WARNING: Resou
 # cpu       = {icon = " ", name = "cpu", color = "(RD)"}
 disk_0    = {icon = " ", name = "disk", color = "(GN)"}
 memory    = {icon = " ", name = "memory", color = "(YW)"}
+battery    = {icon = " ", name = "battery", color = "(YW)"}
 # weather   = {icon = " ", name = "weather", color = "(BE)"} # Requires curl and an emoji font. | WARNING: Resource Intensive
 sep_color = "SEPARATOR"
 colors    = {icon = " ", name = "colors", color = "!DT!", symbol = ""}

--- a/src/catnaplib/global/definitions.nim
+++ b/src/catnaplib/global/definitions.nim
@@ -54,7 +54,7 @@ const
 
     # Stats
     STATNAMES*    = @["username", "hostname", "uptime", "distro",
-                    "kernel", "desktop", "shell", "memory", "terminal",
+                    "kernel", "desktop", "shell", "memory", "battery", "terminal",
                     "cpu", "gpu", "packages", "weather", "colors"]
     STATKEYS*     = @["icon", "name", "color"]
     

--- a/src/catnaplib/platform/fetch.nim
+++ b/src/catnaplib/platform/fetch.nim
@@ -19,6 +19,7 @@ proc fetchSystemInfo*(config: Config, distroId: string = "nil"): FetchInfo =
     result.list["terminal"] = proc(): string = return probe.getTerminal()
     result.list["shell"]    = proc(): string = return probe.getShell()
     result.list["memory"]   = proc(): string = return probe.getMemory()
+    result.list["battery"]   = proc(): string = return probe.getBattery()
     result.list["cpu"]      = proc(): string = return probe.getCpu()
     result.list["gpu"]      = proc(): string = return probe.getGpu()
     result.list["packages"] = proc(): string = return probe.getPackages()

--- a/src/catnaplib/platform/probe.nim
+++ b/src/catnaplib/platform/probe.nim
@@ -122,13 +122,15 @@ proc getMemory*(mb: bool = true): string =
     result = &"{memUsedInt} / {memTotalInt} {suffix} ({percentage}%)"
 
 proc getBattery*(): string =
-    let 
-        batteryPath = "/sys/class/power_supply/BAT0/"
+    let batteryPath = "/sys/class/power_supply/" & getEnv("CATNAP_BATTERY") & "/"
+    
+    # let error checking go first before setting other variables
+    if not dirExists(batteryPath):
+        logError("No battery detected! Have you set $CATNAP_BATTERY?")
+
+    let
         batteryCapacity = readFile(batteryPath & "capacity").strip()
         batteryStatus = readFile(batteryPath & "status").strip()
-    
-    if not dirExists(batteryPath):
-        logError("No battery detected!")
 
     result = &"{batteryCapacity}% ({batteryStatus})"
 

--- a/src/catnaplib/platform/probe.nim
+++ b/src/catnaplib/platform/probe.nim
@@ -121,6 +121,14 @@ proc getMemory*(mb: bool = true): string =
 
     result = &"{memUsedInt} / {memTotalInt} {suffix} ({percentage}%)"
 
+proc getBattery*(): string =
+    let 
+        batteryPath = "/sys/class/power_supply/BAT0/"
+        batteryCapacity = readFile(batteryPath & "capacity").strip()
+        batteryStatus = readFile(batteryPath & "status").strip()
+    
+    result = &"{batteryCapacity}% ({batteryStatus})"
+
 proc getMounts*(): seq[string] =
     proc getMountPoints(): cstring {.importc, varargs, header: "getDisk.h".}
 

--- a/src/catnaplib/platform/probe.nim
+++ b/src/catnaplib/platform/probe.nim
@@ -123,6 +123,7 @@ proc getMemory*(mb: bool = true): string =
     result = &"{memUsedInt} / {memTotalInt} {suffix} ({percentage}%)"
 
 proc getBattery*(): string =
+    # Credits to https://gitlab.com/prashere/battinfo for regex implementation.
     var batteryPath = ""
     
     let 
@@ -132,9 +133,7 @@ proc getBattery*(): string =
     for dir in os.walk_dir(powerPath):
       if re.match(os.last_path_part(dir.path), BATTERY_REGEX):
         batteryPath = dir.path & "/"
-
-    # let error checking go first before setting other variables
-    if not dirExists(batteryPath):
+      else:
         logError("No battery detected!")
 
     let

--- a/src/catnaplib/platform/probe.nim
+++ b/src/catnaplib/platform/probe.nim
@@ -127,6 +127,9 @@ proc getBattery*(): string =
         batteryCapacity = readFile(batteryPath & "capacity").strip()
         batteryStatus = readFile(batteryPath & "status").strip()
     
+    if not dirExists(batteryPath):
+        logError("No battery detected!")
+
     result = &"{batteryCapacity}% ({batteryStatus})"
 
 proc getMounts*(): seq[string] =


### PR DESCRIPTION
### Is your pull request linked to an existing issue?
#115 

### What is your pull request about?:
Adds a battery stat. How it works is Catnap uses a regex search to find the default battery in `/sys/class/power_supply/`.

### Any other disclosures/notices/things to add?
I'm still looking for a way to set the chosen battery in `config.toml`. Contributions appreciated.

Credits to <https://gitlab.com/prashere/battinfo> for the regex stuff.