### PR TITLE
Hopefully adding working MacOS support.

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -19,7 +19,7 @@ desktop   = {icon = " ", name = "desktop", color = "(CN)"}
 # packages  = {icon = " ", name = "packages", color = "(RD)"}  # WARNING: Resource Intensive
 # gpu       = {icon = "󱔐 ", name = "gpu", color = "(MA)"}      # WARNING: Resource Intensive
 # cpu       = {icon = " ", name = "cpu", color = "(RD)"}
-disk_0    = {icon = " ", name = "disk", color = "(GN)"}
+# disk_0    = {icon = " ", name = "disk", color = "(GN)"}
 memory    = {icon = " ", name = "memory", color = "(YW)"}
 # battery    = {icon = " ", name = "battery", color = "(GN)"}
 # weather   = {icon = " ", name = "weather", color = "(BE)"} # Requires curl and an emoji font. | WARNING: Resource Intensive

--- a/src/catnaplib/platform/probe.nim
+++ b/src/catnaplib/platform/probe.nim
@@ -13,8 +13,11 @@ import "../terminal/logging"
 import algorithm
 
 proc getDistro*(): string =
+    when defined(linux):
     # Returns the name of the running linux distro
-    result = "/etc/os-release".loadConfig.getSectionValue("", "PRETTY_NAME") & " " & uname().machine
+        result = "/etc/os-release".loadConfig.getSectionValue("", "PRETTY_NAME") & " " & uname().machine
+    elif defined(macos):
+        result = "MacOS X" & " " & uname().machine
 
 proc getDistroId*(): DistroId =
     # Returns the DistroId of the running linux distro


### PR DESCRIPTION
### Is your pull request linked to an existing issue?
#124 and #120 

### What is your pull request about?:
Fixed the error on MacOS when fetching the distro name by hard coding the OS name instead of relying on `/etc/os-release`, which does not exist on MacOS.

### Any other disclosures/notices/things to add?
I commented out the disk stat because on the BSDs it does not work, and I doubt it will on MacOS either. (Can someone test that out for me?)