### PR TITLE
fix: change config and distros path to be computed at run-time instead of compile-time

### DIFF
--- a/src/catnaplib/global/definitions.nim
+++ b/src/catnaplib/global/definitions.nim
@@ -141,8 +141,8 @@ const
     }.toOrderedTable
 
     # Files / Dirs
-    CONFIGPATH*   = static: joinPath(getConfigDir(), "catnap/config.toml")
-    DISTROSPATH*  = static: joinPath(getConfigDir(), "catnap/distros.toml")
+let CONFIGPATH*   = joinPath(getConfigDir(), "catnap/config.toml")
+let DISTROSPATH*  = joinPath(getConfigDir(), "catnap/distros.toml")
 
 
 proc getCachePath*(): string =


### PR DESCRIPTION
Having these variables be determined at compile-time means that if `HOME` or `XDG_CONFIG_HOME` point to a different directory from what they will point to when the produced binary is used (ie. a different user using the binary, project being built in a sandbox), the binary will still look in those compile-time env var paths.

This commit makes those variables be determined at run-time instead, so that this problem doesn't exist.

NOTE: I don't know much about nim, so if this is the wrong way to make this change, feel free to tell me and I'll try to make it better, or you can change it as well
