### PR TITLE
Added global config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,6 @@
 
 ## v1.1.1
 + Fixed glxinfo output being displayed when fetching GPU
+
+## v1.2.0
++ Added functionality for global configs in /etc/catnap

--- a/src/catnaplib/global/config.nim
+++ b/src/catnaplib/global/config.nim
@@ -1,5 +1,5 @@
 import "../terminal/logging"
-from "definitions" import Config, STATNAMES, STATKEYS, Logo, DISTROSPATH
+from "definitions" import Config, STATNAMES, STATKEYS, Logo, DISTROSPATH, GLOBALCONFIGPATH, GLOBALDISTROSPATH
 from os import fileExists, getEnv, existsEnv
 import strformat
 import strutils
@@ -11,16 +11,29 @@ const ALLOWED_NAME_CHARS = {'A' .. 'Z', 'a' .. 'z', '0' .. '9', '_'}
 proc LoadConfig*(cfgPath: string, dstPath: string): Config =
     # Lads a config file and validates it
 
-    # Validate the config file
+    # Validate the config file and handle global config
+    var configPath: string
     if not fileExists(cfgPath):
-        logError(&"{cfgPath} - file not found!")
+        if fileExists(GLOBALCONFIGPATH):
+            configPath = GLOBALCONFIGPATH
+        else:
+            logError(&"{cfgPath} - file not found!")
+    else:
+        configPath = cfgPath
+        
     
-    # Validate the art file
+    # Validate the art file and handle global art file
+    var distrosPath: string
     if not fileExists(dstPath):
-        logError(&"{dstPath} - file not found!")
+        if fileExists(GLOBALDISTROSPATH):
+            distrosPath = GLOBALDISTROSPATH
+        else:
+            logError(&"{dstPath} - file not found!")
+    else:
+        distrosPath = dstPath
 
-    let tcfg = parsetoml.parseFile(cfgPath)
-    let tdistros = parsetoml.parseFile(dstPath)
+    let tcfg = parsetoml.parseFile(configPath)
+    let tdistros = parsetoml.parseFile(distrosPath)
     
     # Error out if stats missing
     if not tcfg.contains("stats"):

--- a/src/catnaplib/global/definitions.nim
+++ b/src/catnaplib/global/definitions.nim
@@ -144,6 +144,9 @@ const
 let CONFIGPATH*   = joinPath(getConfigDir(), "catnap/config.toml")
 let DISTROSPATH*  = joinPath(getConfigDir(), "catnap/distros.toml")
 
+const GLOBALCONFIGPATH*   = "/etc/catnap/config.toml"
+const GLOBALDISTROSPATH*  = "/etc/catnap/distros.toml"
+
 
 proc getCachePath*(): string =
     result = getEnv("XDG_CACHE_HOME")

--- a/src/catnaplib/global/version.nim
+++ b/src/catnaplib/global/version.nim
@@ -1,1 +1,1 @@
-const VERSION* = static: "1.1.1"
+const VERSION* = static: "1.2.0"


### PR DESCRIPTION
### Is your pull request linked to an existing issue?
Closing #166

### What is your pull request about?:
This PR implements support for global config files located in `/etc/catnap` as requested in #166.

### Any other disclosures/notices/things to add?
Version was updated to 1.2.0
