### PR TITLE
added vram detection and improved gpu formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,7 @@
 > *If you're using openSUSE, please update your distros.toml to the latest version from the repository.*
 + Fixed distroid Fetching and alias handling
 + Added alias to opensuse art
+
+## v1.2.3
++ Improved GPU name formatting
++ Added VRAM detection for dedicated GPUs

--- a/src/catnaplib/global/version.nim
+++ b/src/catnaplib/global/version.nim
@@ -1,1 +1,1 @@
-const VERSION* = static: "1.2.2"
+const VERSION* = static: "1.2.3"

--- a/src/catnaplib/platform/probe.nim
+++ b/src/catnaplib/platform/probe.nim
@@ -334,6 +334,79 @@ proc getPackages*(distroId: DistroId = getDistroId()): string =
     result = count & " [" & pkgManager & "]"
     writeCache(cacheFile, result, initDuration(hours=2))
 
+proc cleanGpuName(raw: string): string =
+    # Strip parenthesised technical details
+    let parenIdx = raw.find('(')
+    result = if parenIdx > 0: raw[0 ..< parenIdx].strip() else: raw.strip()
+
+    # Normalise vendor prefixes so the name is consistent
+    const prefixMap = [
+        ("AMD Radeon",   "AMD Radeon"),
+        ("NVIDIA",       "NVIDIA"),
+        ("Intel",        "Intel"),
+        # Mesa software renderers – collapse to a readable label
+        ("llvmpipe",     "Software (llvmpipe)"),
+        ("softpipe",     "Software (softpipe)"),
+        ("D3D12",        "Software (D3D12)"),
+    ]
+    for (prefix, canon) in prefixMap:
+        if result.toLowerAscii().startsWith(prefix.toLowerAscii()):
+            # Re-attach the canonical prefix while preserving the model suffix
+            if result.len > prefix.len:
+                result = canon & result[prefix.len .. ^1]
+            else:
+                result = canon
+            break
+
+proc getVramMb(): int =
+    # AMD / amdgpu – most reliable
+    let drmBase = "/sys/class/drm"
+    if dirExists(drmBase):
+        for kind in ["card0", "card1", "card2"]:
+            let p = drmBase / kind / "device" / "mem_info_vram_total"
+            if fileExists(p):
+                try:
+                    let bytes = parseBiggestInt(readFile(p).strip())
+                    if bytes > 0:
+                        return int(bytes div (1024 * 1024))
+                except: discard
+
+    # NVIDIA – parse nvidia-smi
+    try:
+        let raw = execProcess("nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null").strip()
+        if raw != "":
+            return parseInt(raw.splitLines()[0].strip())
+    except: discard
+
+    # Intel / generic – drm resource file
+    if dirExists(drmBase):
+        for kind in ["card0", "card1", "card2"]:
+            let p = drmBase / kind / "device" / "resource"
+            if fileExists(p):
+                try:
+                    var best = 0
+                    for line in readFile(p).splitLines():
+                        let parts = line.splitWhitespace()
+                        if parts.len >= 3:
+                            let start = parseHexInt(parts[0])
+                            let stop  = parseHexInt(parts[1])
+                            let size  = int((stop - start + 1) div (1024 * 1024))
+                            if size > best: best = size
+                    if best > 0: return best
+                except: discard
+
+    return 0
+
+proc formatVram(mb: int): string =
+    # Round to the nearest sensible marketing size (e.g. 16376 MB → "16GB").
+    if mb <= 0: return ""
+    let gb = mb div 1024
+    # Snap to the nearest power-of-two GB tier (2, 4, 6, 8, 12, 16, 24, 32 …)
+    const tiers = [2, 4, 6, 8, 10, 12, 16, 20, 24, 32, 48, 64, 80]
+    for t in tiers:
+        if gb <= t: return $t & "GB"
+    return $gb & "GB"
+
 proc getGpu*(): string =
     # Returns the gpu name
     let cacheFile = "gpu".toCachePath
@@ -350,26 +423,34 @@ proc getGpu*(): string =
                 result = "Unknown"
             else: logError("Failed to fetch GPU!")
         else:
-            var device = "Unknown"
+            var rawDevice    = "Unknown"
             var unifiedMemory = ""
             let glxinfo = readFile(tmpFile)
             for line in glxinfo.split('\n'):
-                var split_line = line.strip().split(": ")
+                let split_line = line.strip().split(": ")
                 if split_line[0] == "OpenGL renderer string":
-                    device = split_line[1]
+                    rawDevice = split_line[1]
                 elif split_line[0] == "Unified memory":
                     unifiedMemory = split_line[1]
 
-                if device != "Unknown" and unifiedMemory != "":
+                if rawDevice != "Unknown" and unifiedMemory != "":
                     break
+
+            let device = cleanGpuName(rawDevice)
 
             var gputype = ""
             if unifiedMemory == "yes":
                 gputype = "[integrated]"
             elif unifiedMemory == "no":
                 gputype = "[dedicated]"
+                # Fetch VRAM for discrete GPUs
+                let vram = formatVram(getVramMb())
+                if vram != "":
+                    result = device & " " & vram & " " & gputype
+                    writeCache(cacheFile, result, initDuration(days=1))
+                    return
 
-            result = device & " " & gputype
+            result = device & (if gputype != "": " " & gputype else: "")
 
     elif defined(macosx):
         result = execProcess("system_profiler SPDisplaysDataType | grep 'Chipset Model'").split(": ")[1].split("\n")[0]


### PR DESCRIPTION
### Is your pull request linked to an existing issue?
[#156](https://github.com/iinsertNameHere/catnap/issues/159)

### What is your pull request about?:
I was trying to resolve the very verbose GPU name that shows up when fetching with the gpu stat enabled. 
I saw that another issue had been opened and merged about this but I still had a problem displaying the gpu in my system for some reason.

<img width="1706" height="441" alt="Screenshot2026-04-14 18-30-06" src="https://github.com/user-attachments/assets/79e84a8d-a38c-49cf-8f64-89e7b2c0d130" />

So I added helper functions to cleanup the output from glxinfo and get the vram amount for discrete gpus to display alongside it.

<img width="1005" height="504" alt="Screenshot2026-04-14 18-23-47" src="https://github.com/user-attachments/assets/ed792aeb-a2ac-4088-bd82-c819421f3392" />

### Any other disclosures/notices/things to add?
I was afraid that this would significantly impact performance but after running a few tests it seems to not affect it that much, even though this adds a lot of code to the probe.
I used hyperfine and run the command in a single thread to measure performance, deleting the cache between runs, and the results I got are as follows:

Current build:
<img width="949" height="130" alt="Screenshot2026-04-14 18-20-30" src="https://github.com/user-attachments/assets/c65bbac9-0714-47d9-8644-3b0ef8afaf05" />

My build:
<img width="949" height="130" alt="Screenshot2026-04-14 18-22-46" src="https://github.com/user-attachments/assets/b9c3bd15-c24b-4ede-a4a6-5ba7d4ba4c64" />


